### PR TITLE
fix(gitignore): stop ignoring husky directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 .venv/
 .cache/
 node_modules/
-
-.husky/

--- a/cbc-module.sh
+++ b/cbc-module.sh
@@ -2274,7 +2274,7 @@ mkcommitlint() {
   # --------------------------------------------------------------------------
   local gitignore_file="$target_dir/.gitignore"
 
-  local -a gitignore_entries=(.cache/ node_modules/ .husky/)
+  local -a gitignore_entries=(.cache/ node_modules/)
   local gitignore_entry
 
   if [ ! -f "$gitignore_file" ]; then


### PR DESCRIPTION
Keep tracked Husky hooks out of generated ignore files.
