### PR TITLE
fix(gitignore): avoid blank lines on append

### DIFF
--- a/cbc-module.sh
+++ b/cbc-module.sh
@@ -1644,10 +1644,7 @@ EOF
   if [ -f "$gitignore_file" ]; then
     for gitignore_entry in "${gitignore_entries[@]}"; do
       if ! grep -Eq "^[[:space:]]*${gitignore_entry//\//\/}[[:space:]]*$" "$gitignore_file"; then
-        {
-          printf '\n'
-          printf '%s\n' "$gitignore_entry"
-        } >> "$gitignore_file" || {
+        printf '%s\n' "$gitignore_entry" >> "$gitignore_file" || {
           cbc_style_message "$CATPPUCCIN_RED" "Error: Failed to update .gitignore."
           return 1
         }
@@ -2294,10 +2291,7 @@ mkcommitlint() {
   else
     for gitignore_entry in "${gitignore_entries[@]}"; do
       if ! grep -Eq "^[[:space:]]*${gitignore_entry//\//\/}[[:space:]]*$" "$gitignore_file"; then
-        {
-          printf '\n'
-          printf '%s\n' "$gitignore_entry"
-        } >> "$gitignore_file"
+        printf '%s\n' "$gitignore_entry" >> "$gitignore_file"
       fi
     done
   fi


### PR DESCRIPTION
Remove the unconditional newline before missing .gitignore entries.
Keep mkzendocs and mkcommitlint appends to one entry per line
while preserving the existing duplicate checks.
